### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/cheat.py
+++ b/cheat.py
@@ -48,8 +48,7 @@ def inst(_id):
         els = driver.find_elements_by_class_name('sc-button-play')
         while len(els) > 0:
             el = random.choice(els)
-            driver.execute_script('window.scrollTo(0, %s)'
-                                  % (el.location['y'] - 200))
+            driver.execute_script('window.scrollTo(0, {0!s})'.format((el.location['y'] - 200)))
             el.click()
             time.sleep(7)
             els.remove(el)


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:guy-do-or-die:clicker?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:guy-do-or-die:clicker?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
